### PR TITLE
285[add]初期状態を取得する関数の実装(ブランチ名修正版)

### DIFF
--- a/communication.h
+++ b/communication.h
@@ -3,6 +3,7 @@
 #include<utility>
 #include<vector>
 #include<iostream>
+#include<regex>
 
 class Communication{
 public:
@@ -10,6 +11,9 @@ public:
 
     bool isDetection(std::string url);
 
+    std::pair<std::vector<std::pair<std::tuple<int,int,int>, int>>, std::vector<std::tuple<int,int,int>>> getInitBlockData(std::string url);
 private:
     static size_t writeCallback(void *contents, size_t size, size_t nmemb, void *userp);
+
+    int valueFromKey(std::string& json, std::string key);
 };

--- a/communication.h
+++ b/communication.h
@@ -11,9 +11,7 @@ public:
 
     bool isDetection(std::string url);
 
-    std::pair<std::vector<std::pair<std::tuple<int,int,int>, int>>, std::vector<std::tuple<int,int,int>>> getInitBlockData(std::string url);
+    std::vector<std::pair<std::tuple<int,int,int>, int>> getInitBlockData(std::string url);
 private:
     static size_t writeCallback(void *contents, size_t size, size_t nmemb, void *userp);
-
-    int valueFromKey(std::string& json, std::string key);
 };


### PR DESCRIPTION
[285](https://trello.com/c/LXKUeaZR/285-%E5%88%9D%E6%9C%9F%E7%8A%B6%E6%85%8B%E3%82%92%E5%8F%96%E5%BE%97%E9%96%A2%E6%95%B0%E3%81%AE%E5%AE%9F%E8%A3%85)[add]初期状態を取得する関数の実装 のPRです。
- ブランチ名を修正しました。 
- valueFromKey関数をラムダ式にしました。 
- getInitBlockData関数の型を修正しました。 
